### PR TITLE
Multi switch support for OVS with dpdkvhostuser ports and Libvirt domain templates

### DIFF
--- a/NFs/kvm/kvm_usvhost_vnf.xml
+++ b/NFs/kvm/kvm_usvhost_vnf.xml
@@ -1,0 +1,54 @@
+<domain type="kvm" xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+	<name>example</name>
+	<memory>4194304</memory>
+	<vcpu placement="static">4</vcpu>
+	<cpu mode='host-passthrough'>
+		<topology sockets='1' cores='4' threads='1'/>
+		<numa>
+			<cell id='0' cpus='0-3' memory='4194304' memAccess='shared'/> 
+		</numa>
+	</cpu>
+	<os>
+		<type arch="x86_64" machine="pc-i440fx-2.2">hvm</type>
+		<boot dev="hd"/>
+	</os>
+	<features>
+		<acpi/><apic/>
+		<pae/>
+	</features>
+	<memoryBacking>    <!-- TODO? Have this inserted automatically by orchestrator? -->
+		<hugepages>
+			<page size="1" unit="G" nodeset="0"/>
+		</hugepages>
+	</memoryBacking>
+
+	<devices>
+		<!-- emulator>/home/dverbeir/qemu/qemu_git/x86_64-softmmu/qemu-system-x86_64</emulator -->
+		<disk type="file" device="disk">
+			<source file="/home/nf_repository/kvm/usvhost_vnf.raw"/>
+			<driver name="qemu" type="raw"/>
+			<target dev="vda" bus="virtio"/>
+		</disk>
+		<disk type="block" device="cdrom">
+			<driver name="qemu" type="raw"/>
+			<target dev="hdc" bus="ide"/>
+		</disk>
+		<interface type="vhostuser">
+			<source type="unix" path="/usr/local/var/run/openvswitch/example_1" mode="client"/>
+			<model type="virtio"/>
+		</interface>
+		<interface type="vhostuser">
+			<source type="unix" path="/usr/local/var/run/openvswitch/example_2" mode="client"/>
+			<model type="virtio"/>
+		</interface>
+		<serial type="pty">
+			<target port="0"/>
+		</serial>
+		<console type="pty">
+			<target type="serial" port="0"/>
+		</console>
+		<input type="mouse" bus="ps2"/>
+		<input type="keyboard" bus="ps2"/>
+		<graphics type="vnc" port="-1" autoport="yes" listen="0.0.0.0"/>
+	</devices>
+</domain>

--- a/name-resolver/config/example.xml
+++ b/name-resolver/config/example.xml
@@ -26,6 +26,9 @@
 		In case of KVM virtual machine, the file specifies the URI from which the
 		image of the virtual machine can be retrieved. It is a path on the local
 		file system.
+		Alternatively, the URI can point to an XML Libvirt doamin definition which
+		the orchestrator uses as a template in which it adds or updates the
+		network interfaces, etc. 
 	-->
 
 	<network-function name="example">
@@ -34,6 +37,11 @@
 		<implementation type="dpdk" uri="https://nf_repository.com/example" cores="1" location="remote"/>
 		<implementation type="dpdk" uri="/home/nf_repository/dpdk/example" cores="1" location="local"/>
 		<implementation type="kvm" uri="/home/nf_repository/kvm/example.qcow2"/>
+	</network-function>
+
+	<network-function name="usvhost_example">
+		<!-- Point to a Libvirt XML domain template -->
+		<implementation type="kvm" uri="/home/nf_repository/kvm/kvm_usvhost_vnf.xml"/>
 	</network-function>
 	
 	<network-function name="firewall">

--- a/orchestrator/CMakeLists.txt
+++ b/orchestrator/CMakeLists.txt
@@ -58,8 +58,8 @@ ENDIF()
 
 
 # Rather complicated CMake code for selecting the virtual switch implementation
-SET(VSWITCH_IMPLEMENTATION "XDPD" CACHE STRING "vSwitch implementation: XDPD, OVS")
-SET(VSWITCH_IMPLEMENTATION_VALUES "XDPD" "OVS") #Add here other implementations
+SET(VSWITCH_IMPLEMENTATION "XDPD" CACHE STRING "vSwitch implementation: XDPD, OVS, OVS-DPDK")
+SET(VSWITCH_IMPLEMENTATION_VALUES "XDPD" "OVS" "OVS-DPDK") #Add here other implementations
 SET_PROPERTY(CACHE VSWITCH_IMPLEMENTATION PROPERTY STRINGS ${VSWITCH_IMPLEMENTATION_VALUES})
 LIST(FIND VSWITCH_IMPLEMENTATION_VALUES ${VSWITCH_IMPLEMENTATION} VSWITCH_IMPLEMENTATION_INDEX)
 
@@ -71,6 +71,9 @@ IF(${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 0)
 ENDIF()
 IF(${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 1)
 	ADD_DEFINITIONS(-DVSWITCH_IMPLEMENTATION_OVS)
+ENDIF()
+IF(${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 2)
+	ADD_DEFINITIONS(-DVSWITCH_IMPLEMENTATION_OVSDPDK)
 ENDIF()
 
 # End of the rather complicated CMake code for setting the Openflow version
@@ -227,6 +230,15 @@ IF(VSWITCH_IMPLEMENTATION_INDEX EQUAL 1)
 	network_controller/switch_manager/plugins/ovs/ovs_manager.cc
     )
 ENDIF(VSWITCH_IMPLEMENTATION_INDEX EQUAL 1)
+
+IF(VSWITCH_IMPLEMENTATION_INDEX EQUAL 2)
+    SET(SOURCES2
+    ${SOURCES}
+	network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_manager.h
+	network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_manager.cc
+	network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_constants.h
+    )
+ENDIF(VSWITCH_IMPLEMENTATION_INDEX EQUAL 2)
 
 
 IF(ENABLE_KVM)

--- a/orchestrator/config/kvm_usvhost_nffg.json
+++ b/orchestrator/config/kvm_usvhost_nffg.json
@@ -1,0 +1,29 @@
+{  
+   "flow-graph":{  
+      "VNFs":[  
+         {  
+            "id":"usvhost_example"
+         }
+      ],
+      "flow-rules":[  
+         {  
+            "id":"00000001",
+            "match":{  
+              "port":"dpdk2"
+            },
+            "action":{  
+               "VNF_id":"usvhost_example:1"
+            }
+         },
+         {  
+            "id":"00000002",
+            "match":{  
+               "VNF_id":"usvhost_example:2"
+            },
+            "action":{  
+              "port":"dpdk0"
+            }
+         }
+      ]
+   }
+}

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_constants.h
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_constants.h
@@ -1,0 +1,11 @@
+#ifndef OVSDKDK_CONSTANTS_H_
+#define OVSDKDK_CONSTANTS_H_ 1
+
+/**
+*	@brief: Scripts to manage OVS bridges
+*/
+#define CMD_CREATE_LSI		"./network_controller/switch_manager/plugins/ovs-dpdk/scripts/createLsi.sh"
+#define CMD_ADD_PORT		"./network_controller/switch_manager/plugins/ovs-dpdk/scripts/addPort.sh"
+#define CMD_VIRTUAL_LINK	"./network_controller/switch_manager/plugins/ovs-dpdk/scripts/VirtualLink.sh"
+
+#endif //OVSDKDK_CONSTANTS_H

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_manager.cc
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_manager.cc
@@ -1,0 +1,156 @@
+#include "ovsdpdk_manager.h"
+
+OVSDPDKManager::OVSDPDKManager() : m_NextLsiId(0), m_NextPortId(1) /* 0 is not valid for OVS */
+{
+}
+
+OVSDPDKManager::~OVSDPDKManager()
+{
+}
+
+void OVSDPDKManager::checkPhysicalInterfaces(set<CheckPhysicalPortsIn> cppi)
+{ // SwitchManager implementation
+	//logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "checkPhysicalInterfaces(dpid: %" PRIu64 " NF:%s NFType:%d)\n", anpi.getDpid(), anpi.getNFname().c_str(), anpi.getNFtype());
+}
+
+CreateLsiOut *OVSDPDKManager::createLsi(CreateLsiIn cli)
+{  // SwitchManager implementation
+
+	unsigned int dpid = m_NextLsiId++;
+
+	logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "createLsi() creating LSI %d", dpid);
+
+	stringstream cmd;
+	cmd << CMD_CREATE_LSI << " " << dpid << " " << cli.getControllerAddress() << " " << cli.getControllerPort() << " ";
+	// Set the OpenFlow version
+	switch(OFP_VERSION) {
+		case OFP_10:
+			cmd << "OpenFlow10";
+			break;
+		case OFP_12:
+			cmd << "OpenFlow12";
+			break;
+		case OFP_13:
+			cmd << "OpenFlow13";
+			break;
+	}
+	logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "Executing command \"%s\"", cmd.str().c_str());
+	int retVal = system(cmd.str().c_str());
+	retVal = retVal >> 8;
+	if(retVal == 0) {
+		logger(ORCH_WARNING, MODULE_NAME, __FILE__, __LINE__, "Failed to create LSI");
+		throw OVSDPDKManagerException();
+	}
+
+	// Add ports
+	list<string> ports = cli.getPhysicalPortsName();
+	typedef map<string,unsigned int> PortsNameIdMap;
+	PortsNameIdMap out_physical_ports;
+
+	list<string>::iterator pit = ports.begin();
+	for(; pit != ports.end(); pit++)
+	{
+		// Go create it!
+		unsigned int port_id = m_NextPortId++;
+		logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, " phy port \"%s\" = %d", pit->c_str(), port_id);
+		stringstream cmd_add;
+		cmd_add << CMD_ADD_PORT << " " << dpid << " " << *pit << " " << "dpdk" << " " << port_id;
+		logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "Executing command \"%s\"", cmd_add.str().c_str());
+		int retVal = system(cmd_add.str().c_str());
+		retVal = retVal >> 8;
+		if(retVal == 0) {
+			logger(ORCH_WARNING, MODULE_NAME, __FILE__, __LINE__, "Failed to add port");
+			throw OVSDPDKManagerException();
+		}
+		// TODO - Really check result!
+		out_physical_ports.insert(PortsNameIdMap::value_type(*pit, port_id));
+	}
+
+	// Add NF ports
+	typedef map<string,PortsNameIdMap > NfPortsMapMap;
+	map<string,nf_t> nf_types = cli.getNetworkFunctionsType();
+	NfPortsMapMap out_nf_ports;
+	list<pair<unsigned int, unsigned int> > out_virtual_links;
+	set<string> nfs = cli.getNetworkFunctionsName();
+	for(set<string>::iterator nf = nfs.begin(); nf != nfs.end(); nf++) {
+		nf_t nf_type = nf_types[*nf];
+		list<string> nf_ports = cli.getNetworkFunctionsPortNames(*nf);
+		PortsNameIdMap nf_ports_ids;
+		for(list<string>::iterator nfp = nf_ports.begin(); nfp != nf_ports.end(); nfp++) {
+			unsigned int port_id = m_NextPortId++;
+			const char* port_type = "dpdkvhostuser";  // TODO - dpdkr, dpdkvhostuser, tap, virtio ...
+			logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, " NF port \"%s.%s\" = %d (type=%d)", nf->c_str(), nfp->c_str(), port_id, nf_type);
+			stringstream cmd_add;
+			cmd_add << CMD_ADD_PORT << " " << dpid << " " << *nfp << " " << port_type << " " << port_id;
+			logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "Executing command \"%s\"", cmd_add.str().c_str());
+			int retVal = system(cmd_add.str().c_str());
+			retVal = retVal >> 8;
+			if(retVal == 0) {
+				logger(ORCH_WARNING, MODULE_NAME, __FILE__, __LINE__, "Failed to add port");
+				throw OVSDPDKManagerException();
+			}
+			// TODO - Really check result!
+			nf_ports_ids.insert(PortsNameIdMap::value_type(*nfp, port_id));
+		}
+		out_nf_ports.insert(NfPortsMapMap::value_type(*nf, nf_ports_ids));
+	}
+
+	// Add Ports for Virtual Links (patch ports)
+	list<uint64_t> vlinks = cli.getVirtualLinksRemoteLSI();
+	for(list<uint64_t>::iterator vl = vlinks.begin(); vl != vlinks.end(); vl++) {
+
+		unsigned int s_port_id = m_NextPortId++;
+		unsigned int d_port_id = m_NextPortId++;
+
+		logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, " Virtual link to LSI %u: %u:%u <-> %u:%u", *vl, dpid, s_port_id, *vl, d_port_id);
+		stringstream cmd_add;
+		cmd_add << CMD_VIRTUAL_LINK << " " << dpid << " " << *vl << " " << s_port_id << " " << d_port_id;
+		logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "Executing command \"%s\"", cmd_add.str().c_str());
+		int retVal = system(cmd_add.str().c_str());
+		retVal = retVal >> 8;
+		if(retVal == 0) {
+			logger(ORCH_WARNING, MODULE_NAME, __FILE__, __LINE__, "Failed to create virtual link");
+			throw OVSDPDKManagerException();
+		}
+
+		out_virtual_links.push_back(make_pair(s_port_id, d_port_id));
+	}
+
+	CreateLsiOut *clo = new CreateLsiOut(dpid, out_physical_ports, out_nf_ports, out_virtual_links);
+	return clo;
+}
+
+AddNFportsOut *OVSDPDKManager::addNFPorts(AddNFportsIn anpi)
+{ // SwitchManager implementation
+  
+	AddNFportsOut *anpo = NULL;
+	logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "addNFPorts(dpid: %" PRIu64 " NF:%s NFType:%d)\n", anpi.getDpid(), anpi.getNFname().c_str(), anpi.getNFtype());
+	list<string> nfs_ports = anpi.getNetworkFunctionsPorts();
+	for(list<string>::iterator nfp = nfs_ports.begin(); nfp != nfs_ports.end(); nfp++) {
+		logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "\tport: %s\n", (*nfp).c_str());
+	}
+	return anpo;
+}
+
+AddVirtualLinkOut *OVSDPDKManager::addVirtualLink(AddVirtualLinkIn avli)
+{ // SwitchManager implementation
+	AddVirtualLinkOut *avlo = NULL;
+	logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "addVirtualLink(dpid: %" PRIu64 " -> %" PRIu64 ")\n", avli.getDpidA(), avli.getDpidB());
+	return avlo;
+}
+
+void OVSDPDKManager::destroyLsi(uint64_t dpid)
+{ // SwitchManager implementation
+	logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "destroyLsi(dpid: %" PRIu64 " -> %" PRIu64 ")\n", dpid);
+}
+
+void OVSDPDKManager::destroyVirtualLink(DestroyVirtualLinkIn dvli)
+{ // SwitchManager implementation
+	logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "destroyVirtualLink(%" PRIu64 ".%" PRIu64 " -> %" PRIu64 ".%" PRIu64 ")\n",
+			dvli.getDpidA(), dvli.getIdA(), dvli.getDpidB(), dvli.getIdB());
+
+}
+
+void OVSDPDKManager::destroyNFPorts(DestroyNFportsIn dnpi)
+{ // SwitchManager implementation
+}

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_manager.cc
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_manager.cc
@@ -81,7 +81,7 @@ CreateLsiOut *OVSDPDKManager::createLsi(CreateLsiIn cli)
 			const char* port_type = "dpdkvhostuser";  // TODO - dpdkr, dpdkvhostuser, tap, virtio ...
 			logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, " NF port \"%s.%s\" = %d (type=%d)", nf->c_str(), nfp->c_str(), port_id, nf_type);
 			stringstream cmd_add;
-			cmd_add << CMD_ADD_PORT << " " << dpid << " " << *nfp << " " << port_type << " " << port_id;
+			cmd_add << CMD_ADD_PORT << " " << dpid << " " << dpid << "_" << *nfp << " " << port_type << " " << port_id;
 			logger(ORCH_DEBUG_INFO, MODULE_NAME, __FILE__, __LINE__, "Executing command \"%s\"", cmd_add.str().c_str());
 			int retVal = system(cmd_add.str().c_str());
 			retVal = retVal >> 8;

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_manager.h
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_manager.h
@@ -1,0 +1,68 @@
+#ifndef OVSDPDKManager_H_
+#define OVSDPDKManager_H_ 1
+
+#pragma once
+
+#include "../../switch_manager.h"
+
+#include "../../../../utils/constants.h"
+#include "../../../../utils/sockutils.h"
+#include "../../../../utils/logger.h"
+
+#include "ovsdpdk_constants.h"
+
+#include <json_spirit/json_spirit.h>
+#include <json_spirit/value.h>
+#include <json_spirit/writer.h>
+
+#include <string>
+#include <list>
+#include <sstream>
+#include <getopt.h>
+
+using namespace std;
+using namespace json_spirit;
+
+class LSI;
+
+class OVSDPDKManager : public SwitchManager
+{
+private:
+	unsigned int m_NextLsiId;
+	unsigned int m_NextPortId;
+
+public:
+	OVSDPDKManager();
+
+	~OVSDPDKManager();
+
+	//
+	// SwitchManager interface
+	//
+	
+	CreateLsiOut *createLsi(CreateLsiIn cli);
+
+	AddNFportsOut *addNFPorts(AddNFportsIn anpi);
+
+	AddVirtualLinkOut *addVirtualLink(AddVirtualLinkIn avli);
+
+	void destroyLsi(uint64_t dpid);
+
+	void destroyNFPorts(DestroyNFportsIn dnpi);
+
+	void destroyVirtualLink(DestroyVirtualLinkIn dvli); 
+
+	void checkPhysicalInterfaces(set<CheckPhysicalPortsIn> cppi);
+};
+
+class OVSDPDKManagerException: public SwitchManagerException
+{
+public:
+	virtual const char* what() const throw()
+	{
+		return "OVSDPDKManagerException";
+	}
+};
+
+#endif //OVSDPDKManager_H_
+

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/scripts/VirtualLink.sh
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/scripts/VirtualLink.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#Author: UNIFY Consortium
+#Date: 2015-07-05 
+#Brief: Add a Virtual Link between two bridges (using patch ports)
+
+s_br=`echo br_$1`
+d_br=`echo br_$2`
+s_port_name=`echo VPort$1_$2`
+d_port_name=`echo VPort$2_$1`
+s_port_id=$3
+d_port_id=$4
+
+. ./network_controller/switch_manager/plugins/ovs-dpdk/scripts/ovs.conf
+
+if (( $EUID != 0 ))
+then
+    echo "[$0] This script must be executed with ROOT privileges"
+    exit 0
+fi
+
+VSCTL="$OVS_DIR/utilities/ovs-vsctl"
+
+$VSCTL add-port $s_br $s_port_name -- set Interface $s_port_name type=patch ofport_request=$s_port_id options:peer=$d_port_name
+$VSCTL add-port $d_br $d_port_name -- set Interface $d_port_name type=patch ofport_request=$d_port_id options:peer=$s_port_name
+
+exit 1

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/scripts/addPort.sh
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/scripts/addPort.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+#Author: UNIFY Consortium
+#Date: 2015-07-02 
+#Brief: Add a port to a bridge
+
+#$1 LSI id
+#$2 port name
+#$3 type (dpdk, dpdkr, dpdkvhostuser)
+#$4 port id to assign
+
+bridgeName=`echo br_$1`
+port=$2
+port_type=$3
+port_id=$4
+
+. ./network_controller/switch_manager/plugins/ovs-dpdk/scripts/ovs.conf
+
+if (( $EUID != 0 ))
+then
+    echo "[$0] This script must be executed with ROOT privileges"
+    exit 0
+fi
+
+VSCTL="$OVS_DIR/utilities/ovs-vsctl"
+
+
+echo "[$0] Adding port $port to bridge $bridgeName (type=$port_type id=$port_id)"
+$VSCTL --no-wait add-port $bridgeName $port -- set Interface $port type=$port_type ofport_request=$port_id
+
+exit 1
+

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/scripts/createLsi.sh
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/scripts/createLsi.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#Author: UNIFY Consortium
+#Date: 2015-07-02 
+#Brief: Add a port to a bridge
+
+#$1 LSI id
+#$2 controller ip
+#$3 controller port
+
+bridgeName=`echo br_$1`
+controller_ip=$2
+controller_port=$3
+ofp_version=$4
+
+. ./network_controller/switch_manager/plugins/ovs-dpdk/scripts/ovs.conf
+
+if (( $EUID != 0 ))
+then
+    echo "[$0] This script must be executed with ROOT privileges"
+    exit 0
+fi
+
+VSCTL="$OVS_DIR/utilities/ovs-vsctl"
+
+
+echo "[$0] Creating bridge $bridgeName"
+$VSCTL --no-wait add-br $bridgeName
+$VSCTL --no-wait set bridge $bridgeName datapath_type=netdev
+$VSCTL --no-wait set bridge $bridgeName protocols=$ofp_version
+$VSCTL --no-wait set-controller $bridgeName tcp:$controller_ip:$controller_port
+
+exit 1
+

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/scripts/ovs.conf
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-dpdk/scripts/ovs.conf
@@ -1,0 +1,1 @@
+OVS_DIR=/home/dverbeir/ovs/ovs/

--- a/orchestrator/node_resource_manager/graph_manager/graph_manager.h
+++ b/orchestrator/node_resource_manager/graph_manager/graph_manager.h
@@ -24,6 +24,10 @@
 	#include "../../network_controller/switch_manager/plugins/ovs/ovs_manager.h"
 	#define SWITCH_MANAGER_IMPLEMENTATION OVSManager
 #endif
+#ifdef VSWITCH_IMPLEMENTATION_OVSDPDK
+	#include "../../network_controller/switch_manager/plugins/ovs-dpdk/ovsdpdk_manager.h"
+	#define SWITCH_MANAGER_IMPLEMENTATION OVSDPDKManager
+#endif
 //[+] Add here other implementations for the virtual switch
 
 #include <list>


### PR DESCRIPTION
This supports:
* Basic LSI creation in OVS through ovs-vsctl scripts (only creation, no update, not delete yet)
* KVM-based VNF through Libvirt but with a template XML domain definition instead of the hard-coded definition

Only "dpdkvhostuser" (i.e. DPDK user-space in OVS using QEMU virtio vhost-user) ports are currently supported for the VNFs using the Libvirt template approach
Only tested with DPDK physical and dpdkvhostuser ports in OVS.